### PR TITLE
README: fix demo URL markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tools used:
 - Mapbox Directions API
 
 
-__Geofencing Demo:__ [https://www.mapbox.com/bites/00223/]()
+__Geofencing Demo:__ https://www.mapbox.com/bites/00223/
 
 ### Running locally
 
@@ -22,4 +22,4 @@ __Geofencing Demo:__ [https://www.mapbox.com/bites/00223/]()
 
     npm run build
     
-__Last updated:__ 19 Feb 2016
+__Last updated:__ 5 Feb 2017


### PR DESCRIPTION
Previously the URL demo was in markdown
of the form:
[https://www.mapbox.com/bites/00223/]()

which when clicked would instead lead to non-existent URL
https://github.com/mollymerp/geofencing/blob/master

instead of going to the demo.

This fixes it by removing the markdown
since it is already a well schemeified URL so the Markdown
viewer will render it as such and clickable.